### PR TITLE
feat: schedule selector

### DIFF
--- a/src/components/AvailabilityZone.tsx
+++ b/src/components/AvailabilityZone.tsx
@@ -39,7 +39,7 @@ const TimeLabel: React.FC<{ time: Date }> = ({ time }) => {
 
 export const MyAvailabilityZone: React.FC = () => {
   const [schedule, setSchedule] = useState<Date[]>([]);
-  console.log(schedule);
+  console.log(schedule.sort());
   return (
     <div className="relative h-[500px]">
       <div className="absolute top-4 left-8 flex flex-row items-center gap-1 bg-white text-sm text-gray-500">
@@ -61,12 +61,9 @@ export const MyAvailabilityZone: React.FC = () => {
             occuringDates={[
               new Date(2022, 8, 30),
               new Date(2022, 9, 2),
-              new Date(2022, 9, 3),
-              new Date(2022, 9, 4),
               new Date(2022, 9, 6),
               new Date(2022, 9, 10),
               new Date(2022, 9, 11),
-              new Date(2022, 9, 12),
             ]}
             startTime={8}
             endTime={20}
@@ -98,16 +95,13 @@ const Parachute_ScheduleSelector: React.FC<{
     ) {
       console.log(date);
       acc.push(index);
-    } else if (index == arr.length - 1) {
-      acc.push(index + 1);
     }
     return acc;
   }, [] as number[]);
-  console.log("asd", consecutiveDates);
-
   return (
     <>
       {consecutiveDates.map((dateIndex, index, arr) => {
+        const length = occuringDates.length;
         return (
           <ScheduleSelector
             key={index}
@@ -115,7 +109,11 @@ const Parachute_ScheduleSelector: React.FC<{
             startDate={
               dateIndex == 0 ? occuringDates[0] : occuringDates[dateIndex]
             }
-            numDays={index == arr.length - 1 ? 1 : arr[index + 1] - dateIndex}
+            numDays={
+              index == arr.length - 1
+                ? length - dateIndex
+                : (arr[index + 1] ?? length) - dateIndex
+            }
             minTime={startTime}
             maxTime={endTime}
             hourlyChunks={4}
@@ -125,7 +123,7 @@ const Parachute_ScheduleSelector: React.FC<{
               return dateIndex == 0 ? (
                 <TimeLabel time={time} />
               ) : (
-                <TimeLabel time={new Date()} />
+                <TimeLabel time={new Date("")} />
               );
             }}
             renderDateLabel={(datetime) => {

--- a/src/components/AvailabilityZone.tsx
+++ b/src/components/AvailabilityZone.tsx
@@ -17,12 +17,20 @@ const TimeslotBlock: React.FC<{ selected: boolean; datetime: Date }> = ({
     // returns div with whole hours thicker than half hours, make half hours dotted
     <div
       className={`h-4 w-20 border border-t-0 border-black ${
-        !selected || datetime.getMinutes() == 45
+        !selected && datetime.getMinutes() == 45
           ? "border-black"
-          : !selected || datetime.getMinutes() == 15
+          : !selected && datetime.getMinutes() == 15
           ? "border-b-gray-500"
           : "border-b-gray-300"
-      } ${selected ? "border-black bg-[#79ffe1]" : ""}`}
+      } ${
+        selected
+          ? datetime.getMinutes() == 45
+            ? "border-b-black bg-[#79ffe1]"
+            : datetime.getMinutes() == 15
+            ? "border-b-gray-500 bg-[#79ffe1]"
+            : "border-b-gray-300 bg-[#79ffe1]"
+          : ""
+      }`}
     />
   );
 };

--- a/src/components/AvailabilityZone.tsx
+++ b/src/components/AvailabilityZone.tsx
@@ -8,12 +8,21 @@ import {
 import ScheduleSelector from "react-schedule-selector";
 import { IoEarthSharp } from "react-icons/io5";
 
-const TimeslotBlock: React.FC<{ selected: boolean }> = ({ selected }) => {
+const TimeslotBlock: React.FC<{ selected: boolean; datetime: Date }> = ({
+  selected,
+  datetime,
+}) => {
+  console.log(datetime.getMinutes());
   return (
+    // returns div with whole hours thicker than half hours, make half hours dotted
     <div
       className={`h-4 w-20 border border-t-0 border-black ${
-        selected ? "bg-black" : ""
-      }`}
+        !selected || datetime.getMinutes() == 45
+          ? "border-black"
+          : !selected || datetime.getMinutes() == 15
+          ? "border-b-gray-500"
+          : "border-b-gray-300"
+      } ${selected ? "border-black bg-[#79ffe1]" : ""}`}
     />
   );
 };
@@ -146,14 +155,15 @@ const Parachute_ScheduleSelector: React.FC<{
               return <DateLabel datetime={datetime} />;
             }}
             renderDateCell={(datetime, selected) => {
+              console.log("asdfasdfasdfasf", datetime);
               return isInteractable ? (
-                <TimeslotBlock selected={selected} />
+                <TimeslotBlock selected={selected} datetime={datetime} />
               ) : (
                 <div
                   onMouseEnter={() => setHoveredTime(datetime)}
                   onMouseLeave={() => setHoveredTime(null)}
                 >
-                  <TimeslotBlock selected={false} />
+                  <TimeslotBlock selected={false} datetime={datetime} />
                 </div>
               );
             }}

--- a/src/components/AvailabilityZone.tsx
+++ b/src/components/AvailabilityZone.tsx
@@ -29,10 +29,18 @@ const DateLabel: React.FC<{ datetime: Date }> = ({ datetime }) => {
   );
 };
 
-const TimeLabel: React.FC<{ time: Date }> = ({ time }) => {
+const TimeLabel: React.FC<{ time: Date; showTime: boolean }> = ({
+  time,
+  showTime,
+}) => {
   return (
-    <div className="relative bottom-[9px] w-16 text-right text-xs text-gray-500">
-      {time.getMinutes() % 30 == 0 ? format(time, "p") : ""}
+    <div
+      className={
+        "relative bottom-[9px] text-right text-xs text-gray-500 " +
+        (showTime ? "w-16" : "w-10")
+      }
+    >
+      {showTime && (time.getMinutes() % 30 == 0 ? format(time, "p") : "")}
     </div>
   );
 };
@@ -120,11 +128,7 @@ const Parachute_ScheduleSelector: React.FC<{
             rowGap="0px"
             columnGap="10px"
             renderTimeLabel={(time) => {
-              return dateIndex == 0 ? (
-                <TimeLabel time={time} />
-              ) : (
-                <TimeLabel time={new Date("")} />
-              );
+              return <TimeLabel time={time} showTime={dateIndex == 0} />;
             }}
             renderDateLabel={(datetime) => {
               return <DateLabel datetime={datetime} />;

--- a/src/components/AvailabilityZone.tsx
+++ b/src/components/AvailabilityZone.tsx
@@ -56,17 +56,77 @@ export const MyAvailabilityZone: React.FC = () => {
         </div>
       </div>
       <div className="h-full w-full flex-row items-center overflow-auto px-32 py-20">
-        <div className="w-fit">
+        <div className="flex w-fit flex-row">
+          <Parachute_ScheduleSelector
+            occuringDates={[
+              new Date(2022, 8, 30),
+              new Date(2022, 9, 2),
+              new Date(2022, 9, 3),
+              new Date(2022, 9, 4),
+              new Date(2022, 9, 6),
+              new Date(2022, 9, 10),
+              new Date(2022, 9, 11),
+              new Date(2022, 9, 12),
+            ]}
+            startTime={8}
+            endTime={20}
+            schedule={schedule}
+            setSchedule={setSchedule}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const Parachute_ScheduleSelector: React.FC<{
+  occuringDates: Date[];
+  startTime: number;
+  endTime: number;
+  schedule: Date[];
+  setSchedule: React.Dispatch<React.SetStateAction<Date[]>>;
+}> = ({ occuringDates, startTime, endTime, schedule, setSchedule }) => {
+  // find index of consecutive dates
+  const consecutiveDates = occuringDates.reduce((acc, date, index, arr) => {
+    if (index == 0) {
+      acc.push(index);
+      return acc;
+    }
+    // checks for consecutive index
+    if (
+      add(arr[index - 1] ?? new Date(), { days: 1 }).getDate() != date.getDate()
+    ) {
+      console.log(date);
+      acc.push(index);
+    } else if (index == arr.length - 1) {
+      acc.push(index + 1);
+    }
+    return acc;
+  }, [] as number[]);
+  console.log("asd", consecutiveDates);
+
+  return (
+    <>
+      {consecutiveDates.map((dateIndex, index, arr) => {
+        return (
           <ScheduleSelector
+            key={index}
             selection={schedule}
-            numDays={5}
-            minTime={8}
-            maxTime={22}
+            startDate={
+              dateIndex == 0 ? occuringDates[0] : occuringDates[dateIndex]
+            }
+            numDays={index == arr.length - 1 ? 1 : arr[index + 1] - dateIndex}
+            minTime={startTime}
+            maxTime={endTime}
             hourlyChunks={4}
             rowGap="0px"
             columnGap="10px"
             renderTimeLabel={(time) => {
-              return <TimeLabel time={time} />;
+              return dateIndex == 0 ? (
+                <TimeLabel time={time} />
+              ) : (
+                <TimeLabel time={new Date()} />
+              );
             }}
             renderDateLabel={(datetime) => {
               return <DateLabel datetime={datetime} />;
@@ -76,9 +136,9 @@ export const MyAvailabilityZone: React.FC = () => {
             }}
             onChange={setSchedule}
           />
-        </div>
-      </div>
-    </div>
+        );
+      })}
+    </>
   );
 };
 

--- a/src/components/AvailabilityZone.tsx
+++ b/src/components/AvailabilityZone.tsx
@@ -17,20 +17,12 @@ const TimeslotBlock: React.FC<{ selected: boolean; datetime: Date }> = ({
     // returns div with whole hours thicker than half hours, make half hours dotted
     <div
       className={`h-4 w-20 border border-t-0 border-black ${
-        !selected && datetime.getMinutes() == 45
+        datetime.getMinutes() == 45
           ? "border-black"
-          : !selected && datetime.getMinutes() == 15
+          : datetime.getMinutes() == 15
           ? "border-b-gray-500"
           : "border-b-gray-300"
-      } ${
-        selected
-          ? datetime.getMinutes() == 45
-            ? "border-b-black bg-[#79ffe1]"
-            : datetime.getMinutes() == 15
-            ? "border-b-gray-500 bg-[#79ffe1]"
-            : "border-b-gray-300 bg-[#79ffe1]"
-          : ""
-      }`}
+      } ${selected ? "bg-[#79ffe1]" : ""}`}
     />
   );
 };

--- a/src/components/AvailabilityZone.tsx
+++ b/src/components/AvailabilityZone.tsx
@@ -66,6 +66,7 @@ export const MyAvailabilityZone: React.FC = () => {
       <div className="h-full w-full flex-row items-center overflow-auto px-32 py-20">
         <div className="flex w-fit flex-row">
           <Parachute_ScheduleSelector
+            isInteractable
             occuringDates={[
               new Date(2022, 8, 30),
               new Date(2022, 9, 2),
@@ -77,6 +78,7 @@ export const MyAvailabilityZone: React.FC = () => {
             endTime={20}
             schedule={schedule}
             setSchedule={setSchedule}
+            setHoveredTime={() => void 0}
           />
         </div>
       </div>
@@ -89,8 +91,18 @@ const Parachute_ScheduleSelector: React.FC<{
   startTime: number;
   endTime: number;
   schedule: Date[];
-  setSchedule: React.Dispatch<React.SetStateAction<Date[]>>;
-}> = ({ occuringDates, startTime, endTime, schedule, setSchedule }) => {
+  setSchedule?: React.Dispatch<React.SetStateAction<Date[]>>;
+  setHoveredTime: React.Dispatch<React.SetStateAction<Date | null>>;
+  isInteractable: boolean;
+}> = ({
+  occuringDates,
+  startTime,
+  endTime,
+  schedule,
+  setSchedule,
+  setHoveredTime,
+  isInteractable,
+}) => {
   // find index of consecutive dates
   const consecutiveDates = occuringDates.reduce((acc, date, index, arr) => {
     if (index == 0) {
@@ -133,10 +145,19 @@ const Parachute_ScheduleSelector: React.FC<{
             renderDateLabel={(datetime) => {
               return <DateLabel datetime={datetime} />;
             }}
-            renderDateCell={(_, selected) => {
-              return <TimeslotBlock selected={selected} />;
+            renderDateCell={(datetime, selected) => {
+              return isInteractable ? (
+                <TimeslotBlock selected={selected} />
+              ) : (
+                <div
+                  onMouseEnter={() => setHoveredTime(datetime)}
+                  onMouseLeave={() => setHoveredTime(null)}
+                >
+                  <TimeslotBlock selected={false} />
+                </div>
+              );
             }}
-            onChange={setSchedule}
+            onChange={isInteractable ? setSchedule : () => void 0}
           />
         );
       })}
@@ -188,32 +209,20 @@ export const GroupAvailabilityZone: React.FC = () => {
         </div>
       </div>
       <div className="h-full w-full flex-row items-center overflow-auto px-32 py-20">
-        <div className="w-fit">
-          <ScheduleSelector
-            selection={[]}
-            numDays={5}
-            minTime={8}
-            maxTime={22}
-            hourlyChunks={4}
-            rowGap="0px"
-            columnGap="10px"
-            renderTimeLabel={(time) => {
-              return <TimeLabel time={time} />;
-            }}
-            renderDateLabel={(datetime) => {
-              return <DateLabel datetime={datetime} />;
-            }}
-            renderDateCell={(datetime) => {
-              return (
-                <div
-                  onMouseEnter={() => setHoveredTime(datetime)}
-                  onMouseLeave={() => setHoveredTime(null)}
-                >
-                  <TimeslotBlock selected={false} />
-                </div>
-              );
-            }}
-            onChange={() => void 0}
+        <div className="flex w-fit flex-row">
+          <Parachute_ScheduleSelector
+            isInteractable={false}
+            occuringDates={[
+              new Date(2022, 8, 30),
+              new Date(2022, 9, 2),
+              new Date(2022, 9, 6),
+              new Date(2022, 9, 10),
+              new Date(2022, 9, 11),
+            ]}
+            startTime={8}
+            endTime={20}
+            schedule={[]}
+            setHoveredTime={setHoveredTime}
           />
         </div>
       </div>


### PR DESCRIPTION
Allow for non-consecutive dates to show on the same page, if not consecutive, there will be a spacebar in between to separate them for a nicer indication:

### Photo reference:
<img width="948" alt="Screenshot 2023-04-28 at 23 02 24" src="https://user-images.githubusercontent.com/20884681/235282606-809d351d-9083-446b-be07-df6a390696c4.png">
